### PR TITLE
Moves back the comparison to DrawTurtle

### DIFF
--- a/netlogo-gui/src/main/render/TurtleDrawer.java
+++ b/netlogo-gui/src/main/render/TurtleDrawer.java
@@ -19,21 +19,21 @@ public strictfp class TurtleDrawer {
   public void drawTurtle(GraphicsInterface g, TopologyRenderer topology,
                          org.nlogo.api.Turtle turtle, double patchSize) {
     if (!turtle.hidden()) {
-      drawTurtleShape(g, topology, turtle, patchSize);
-    }
-    if (turtle.hasLabel()) {
-      drawTurtleLabel(g, topology, turtle, patchSize);
+      if (Math.abs(turtle.size() * patchSize) >= MIN_PATCH_SIZE_FOR_TURTLE_SHAPES) {
+        drawTurtleShape(g, topology, turtle, patchSize);
+      } else {
+        topology.drawWrappedRect(g, org.nlogo.api.Color.getColor(turtle.color()),
+            0.0f, turtle.xcor(), turtle.ycor(), turtle.size(), patchSize, true);
+      }
+      if (turtle.hasLabel()) {
+        drawTurtleLabel(g, topology, turtle, patchSize);
+      }
     }
   }
 
   void drawTurtleShape(GraphicsInterface g, TopologyRenderer topology, org.nlogo.api.Turtle turtle, double patchSize) {
-    if (Math.abs(turtle.size() * patchSize) >= MIN_PATCH_SIZE_FOR_TURTLE_SHAPES) {
-	  Drawable d = getShapeFromCacheOrCreateDrawable(turtle, patchSize, shapes.getShape(turtle));
-      topology.wrapDrawable(d, g, turtle.xcor(), turtle.ycor(), turtle.size(), patchSize);
-	} else {
-      topology.drawWrappedRect(g, org.nlogo.api.Color.getColor(turtle.color()),
-		0.0f, turtle.xcor(), turtle.ycor(), turtle.size(), patchSize, true);
-	}
+    Drawable d = getShapeFromCacheOrCreateDrawable(turtle, patchSize, shapes.getShape(turtle));
+    topology.wrapDrawable(d, g, turtle.xcor(), turtle.ycor(), turtle.size(), patchSize);
   }
 
   private Drawable getShapeFromCacheOrCreateDrawable(Turtle turtle, double patchSize, VectorShape shape) {

--- a/netlogo-headless/src/main/render/TurtleDrawer.java
+++ b/netlogo-headless/src/main/render/TurtleDrawer.java
@@ -19,21 +19,21 @@ public strictfp class TurtleDrawer {
   public void drawTurtle(GraphicsInterface g, TopologyRenderer topology,
                          org.nlogo.api.Turtle turtle, double patchSize) {
     if (!turtle.hidden()) {
-      drawTurtleShape(g, topology, turtle, patchSize);
-    }
-    if (turtle.hasLabel()) {
-      drawTurtleLabel(g, topology, turtle, patchSize);
+      if (Math.abs(turtle.size() * patchSize) >= MIN_PATCH_SIZE_FOR_TURTLE_SHAPES) {
+        drawTurtleShape(g, topology, turtle, patchSize);
+      } else {
+        topology.drawWrappedRect(g, org.nlogo.api.Color.getColor(turtle.color()),
+            0.0f, turtle.xcor(), turtle.ycor(), turtle.size(), patchSize, true);
+      }
+      if (turtle.hasLabel()) {
+        drawTurtleLabel(g, topology, turtle, patchSize);
+      }
     }
   }
 
   void drawTurtleShape(GraphicsInterface g, TopologyRenderer topology, org.nlogo.api.Turtle turtle, double patchSize) {
-    if (Math.abs(turtle.size() * patchSize) >= MIN_PATCH_SIZE_FOR_TURTLE_SHAPES) {
-	  Drawable d = getShapeFromCacheOrCreateDrawable(turtle, patchSize, shapes.getShape(turtle));
-      topology.wrapDrawable(d, g, turtle.xcor(), turtle.ycor(), turtle.size(), patchSize);
-	} else {
-      topology.drawWrappedRect(g, org.nlogo.api.Color.getColor(turtle.color()),
-		0.0f, turtle.xcor(), turtle.ycor(), turtle.size(), patchSize, true);
-	}
+    Drawable d = getShapeFromCacheOrCreateDrawable(turtle, patchSize, shapes.getShape(turtle));
+    topology.wrapDrawable(d, g, turtle.xcor(), turtle.ycor(), turtle.size(), patchSize);
   }
 
   private Drawable getShapeFromCacheOrCreateDrawable(Turtle turtle, double patchSize, VectorShape shape) {


### PR DESCRIPTION
This does make turtles visible with negative size. 
Adding something in drawTurtleShape that checks turtle.size() < 0 could make them both go away.
Neater would be to do this before we get to the renderer so it's consistent with 2D and 3D.